### PR TITLE
Update PowerShell Core to 6.1.0

### DIFF
--- a/Casks/powershell.rb
+++ b/Casks/powershell.rb
@@ -1,8 +1,8 @@
 cask 'powershell' do
-  version '6.0.4'
-  sha256 '0c59ff0fcacc957342012f44fcb8db255fd05babd081455edb2648566e2b29cc'
+  version '6.1.0'
+  sha256 'aa7bbd2c8286639fd26cffaf3e586bc08dbc6e67b554a6291fdedebd140bd07d'
 
-  url "https://github.com/PowerShell/PowerShell/releases/download/v#{version}/powershell-#{version}-osx.10.12-x64.pkg"
+  url "https://github.com/PowerShell/PowerShell/releases/download/v#{version}/powershell-#{version}-osx-x64.pkg"
   appcast 'https://github.com/PowerShell/PowerShell/releases.atom'
   name 'PowerShell'
   homepage 'https://github.com/PowerShell/PowerShell'
@@ -10,7 +10,7 @@ cask 'powershell' do
   depends_on formula: 'openssl'
   depends_on macos: '>= :sierra'
 
-  pkg "powershell-#{version}-osx.10.12-x64.pkg"
+  pkg "powershell-#{version}-osx-x64.pkg"
 
   uninstall pkgutil: 'com.microsoft.powershell'
 


### PR DESCRIPTION
PowerShell Core 6.1.0 was released today here: https://github.com/PowerShell/PowerShell/releases

* Updated SHA-256 hash
* Updated URL structure, removing Mac OS version from package file name
* Tested changes, per pull request guidelines

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

```
PS > brew cask style --fix ./powershell.rb
1 file inspected, no offenses detected
PS > brew cask audit --download ./powershell.rb
==> Downloading https://github.com/PowerShell/PowerShell/releases/download/v6.1.0/powershell-6.1.0-osx-x64.pkg
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws.com/49609581/2add5500-b738-11e8-907a-7ce847a602d6?X-Amz-Algorithm=AWS4-HMAC-S
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'powershell'.
audit for powershell: passed
```
